### PR TITLE
Fix lifecycle naming and proxy behavior, update Action docs, add tests

### DIFF
--- a/Example/EasyAlert/SwiftUI/ContentView.swift
+++ b/Example/EasyAlert/SwiftUI/ContentView.swift
@@ -115,7 +115,7 @@ struct MessageAlertSectionView: View {
         let confirm = Action(title: "确定", style: .default)
         let ignore = Action(title: "忽略", style: .destructive)
         alert.addActions([cancel, confirm, ignore])
-        alert.addListener(LiftcycleCallback(willShow: {
+        alert.addListener(LifecycleCallback(willShow: {
           print("Alert will show.")
         }, didShow: {
           print("Alert did show.")

--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,11 @@ let package = Package(
 //                .product(name: "SnapKit", package: "SnapKit")
 //            ],
             path: "Sources"
+        ),
+        .testTarget(
+            name: "EasyAlertTests",
+            dependencies: ["EasyAlert"],
+            path: "Tests"
         )
     ]
 )

--- a/Sources/Extra/Action/Action.swift
+++ b/Sources/Extra/Action/Action.swift
@@ -47,7 +47,7 @@ import UIKit
     
     /// 是否可用
     ///
-    /// isEnabled 为 true 时，action view 将无法点击。
+    /// isEnabled 为 false 时，action view 将无法点击。
     public var isEnabled: Bool = true {
         didSet {
             guard let representationView = view?.superview as? ActionCustomViewRepresentationView else {

--- a/Sources/Extra/Action/ActionGroupView.swift
+++ b/Sources/Extra/Action/ActionGroupView.swift
@@ -174,7 +174,7 @@ class ActionGroupView: UIView, AlertContent {
     }
 }
 
-extension ActionGroupView: LiftcycleListener {
+extension ActionGroupView: LifecycleListener {
     
     func willShow() {
         if let customController {

--- a/Sources/Lite/Alert/Alert.swift
+++ b/Sources/Lite/Alert/Alert.swift
@@ -36,7 +36,7 @@ import UIKit
     
     private let keyboardEventMonitor = KeyboardEventMonitor()
     
-    private var liftcycleListeners: [LiftcycleListener] = []
+    private var lifecycleListeners: [LifecycleListener] = []
     
     private var orientationChangeToken: NotificationToken?
     
@@ -112,8 +112,8 @@ import UIKit
         }
     }
     
-    public func addListener(_ listener: LiftcycleListener) {
-        liftcycleListeners.append(listener)
+    public func addListener(_ listener: LifecycleListener) {
+        lifecycleListeners.append(listener)
     }
     
     public func show(in hosting: AlertHosting? = nil) {
@@ -230,7 +230,7 @@ extension Alert {
     private func performShowWithAnimation() {
         isActive = true
         willShow()
-        liftcycleListeners.forEach { $0.willShow() }
+        lifecycleListeners.forEach { $0.willShow() }
         if let viewController = alertContent as? UIViewController {
             viewController.beginAppearanceTransition(true, animated: true)
         }
@@ -239,7 +239,7 @@ extension Alert {
         tapTarget.tapGestureRecognizer.isEnabled = false
         aniamtor.show(context: layoutContext) { [weak self] in
             self?.didShow()
-            self?.liftcycleListeners.forEach { $0.didShow() }
+            self?.lifecycleListeners.forEach { $0.didShow() }
             self?.alertContainerController.view.isUserInteractionEnabled = true
             self?.tapTarget.tapGestureRecognizer.isEnabled = true
             if let viewController = self?.alertContent as? UIViewController {
@@ -284,7 +284,7 @@ extension Alert {
     private func dismissAlert(completion: (() -> Void)?) {
         isActive = false
         willDismiss()
-        liftcycleListeners.forEach { $0.willDismiss() }
+        lifecycleListeners.forEach { $0.willDismiss() }
         if let viewController = alertContent as? UIViewController {
             viewController.beginAppearanceTransition(false, animated: true)
         }
@@ -293,7 +293,7 @@ extension Alert {
         tapTarget.tapGestureRecognizer.isEnabled = false
         aniamtor.dismiss(context: layoutContext) { [weak self] in
             self?.didDismiss()
-            self?.liftcycleListeners.forEach { $0.didDismiss() }
+            self?.lifecycleListeners.forEach { $0.didDismiss() }
             if let viewController = self?.alertContent as? UIViewController {
                 viewController.endAppearanceTransition()
             }

--- a/Sources/Lite/Alert/LifecycleListener.swift
+++ b/Sources/Lite/Alert/LifecycleListener.swift
@@ -1,5 +1,5 @@
 //
-//  LiftcycleListener.swift
+//  LifecycleListener.swift
 //  EasyAlert
 //
 //  Created by iya on 2022/5/28.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-@MainActor public protocol LiftcycleListener {
+@MainActor public protocol LifecycleListener {
     
     func willShow()
     
@@ -18,7 +18,7 @@ import Foundation
     func didDismiss()
 }
 
-extension LiftcycleListener {
+extension LifecycleListener {
     
     public func willShow() { }
     
@@ -29,7 +29,7 @@ extension LiftcycleListener {
     public func didDismiss() { }
 }
 
-public struct LiftcycleCallback: LiftcycleListener {
+public struct LifecycleCallback: LifecycleListener {
     
     public typealias Handler = () -> Void
     

--- a/Sources/Lite/SwiftUI/Alert+SwiftUI.swift
+++ b/Sources/Lite/SwiftUI/Alert+SwiftUI.swift
@@ -98,7 +98,7 @@ private struct AlertController<Content: View>: UIViewControllerRepresentable {
                     content(alert)
                 })
                 alert.backdrop.allowDismissWhenBackgroundTouch = allowDismissWhenBackgroundTouch
-                alert.addListener(LiftcycleCallback(willShow: {
+                alert.addListener(LifecycleCallback(willShow: {
                     alreadyPresented = true
                 }, willDismiss: {
                     isPresented = false

--- a/Sources/Lite/Utils/Proxy.swift
+++ b/Sources/Lite/Utils/Proxy.swift
@@ -41,7 +41,7 @@ class Proxy: NSObject /* & NSProxy */ {
     }
     
     override func isMember(of aClass: AnyClass) -> Bool {
-        return isMember(of: aClass)
+        return target.isMember(of: aClass)
     }
     
     override func conforms(to aProtocol: Protocol) -> Bool {

--- a/Tests/EasyAlertTests/ActionTests.swift
+++ b/Tests/EasyAlertTests/ActionTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import EasyAlert
+import UIKit
+
+final class ActionTests: XCTestCase {
+
+    @MainActor
+    final class DummyActionView: UIControl, ActionContent {
+        var title: String?
+        var style: Action.Style = .default
+    }
+
+    func testIsEnabledPropagatesToRepresentationView() {
+        let actionView = DummyActionView()
+        let action = Action(view: actionView)
+        let representation = ActionCustomViewRepresentationView()
+        representation.action = action
+
+        action.isEnabled = false
+        XCTAssertFalse(representation.isEnabled)
+    }
+
+    func testHandlerCalled() {
+        let expectation = XCTestExpectation(description: "handler called")
+        let action = Action(title: "Test", style: .default) { _ in
+            expectation.fulfill()
+        }
+        action.handler?(action)
+        wait(for: [expectation], timeout: 0.1)
+    }
+}


### PR DESCRIPTION
## Summary
- rename "Liftcycle" to "Lifecycle" across API and examples
- fix `Proxy.isMember(of:)` recursion bug
- clarify `Action.isEnabled` documentation
- add `ActionTests` exercising handler and enabled state

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_68c6b7db98948323a23d058bd629e703